### PR TITLE
Services

### DIFF
--- a/tracker.js
+++ b/tracker.js
@@ -36,7 +36,7 @@ function track() {
             event.application_uris = vcapApplication.application_uris;
         }
 
-        var url = 'https://deployment-tracker.mybluemix.net/api/v1/track';
+        var url = 'https://deployment-tracker-gesticulatory-nonaccretion.mybluemix.net/api/v1/track';
         restler.postJson(url, event).on('complete', function (data) {
             console.log('Uploaded stats', data);
         });

--- a/tracker.js
+++ b/tracker.js
@@ -7,7 +7,8 @@ var restler = require('restler'),
 
 function track() {
     var pkg = require(path.join(path.dirname(module.parent.filename), 'package.json')),
-        vcapApplication;
+        vcapApplication,
+        vcapServices;
 
     if (process.env.VCAP_APPLICATION) {
         vcapApplication = JSON.parse(process.env.VCAP_APPLICATION);
@@ -36,9 +37,17 @@ function track() {
             event.application_uris = vcapApplication.application_uris;
         }
 
+        if (process.env.VCAP_SERVICES) {
+            vcapServices =  JSON.parse(process.env.VCAP_SERVICES);
+            event.bound_vcap_services = [];
+            Object.keys(vcapServices).forEach(function(service_label) {
+                event.bound_vcap_services.push({[service_label]: vcapServices[service_label].length});
+            });
+        }       
+
         var url = 'https://deployment-tracker-gesticulatory-nonaccretion.mybluemix.net/api/v1/track';
         restler.postJson(url, event).on('complete', function (data) {
-            console.log('Uploaded stats', data);
+            console.log('Uploaded stats to ' + url + ' ' + data);
         });
     }
 }


### PR DESCRIPTION
Added new `bound_vcap_services` property to payload if at least one service is bound to the application:
`{ bound_vcap_services : [ {<service>: <service_instance_count> }] }`.

`<service>` is the service's label (e.g. _cloudantNoSQLDB) and `<service_instance_count>` the number of service instances that are bound to the app.

Example:
`{ bound_vcap_services : [ {'cloudantNoSQLDB': 2 }, {'rediscloud': 1 }] }`
