### PR TITLE
capture bound services and runtime environment information

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Sample web applications that include this package may be configured to track dep
 * Application Version (`application_version`)
 * Application URIs (`application_uris`)
 * Labels of bound services
-* Number of instances for each bound service
+* Number of instances for each bound service and associated plan information
 
 This data is collected from the `package.json` file in the sample application and the `VCAP_APPLICATION` and `VCAP_SERVICES` environment variables in IBM Bluemix and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Bluemix to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ Sample web applications that include this package may be configured to track dep
 * Space ID (`space_id`)
 * Application Version (`application_version`)
 * Application URIs (`application_uris`)
+* Labels of bound services
+* Number of instances for each bound service
 
-This data is collected from the `package.json` file in the sample application and the `VCAP_APPLICATION` environment variable in IBM Bluemix and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Bluemix to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
+This data is collected from the `package.json` file in the sample application and the `VCAP_APPLICATION` and `VCAP_SERVICES` environment variables in IBM Bluemix and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Bluemix to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
 
 ## Disabling Deployment Tracking
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-deployment-tracker-client",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": false,
   "main": "tracker.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-deployment-tracker-client",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "private": false,
   "main": "tracker.js",
   "repository": {

--- a/tracker.js
+++ b/tracker.js
@@ -45,6 +45,7 @@ function track() {
                 });                
             }
         }
+        event.runtime = 'nodejs';
 
         var url = 'https://deployment-tracker.mybluemix.net/api/v1/track';
         restler.postJson(url, event).on('complete', function (data) {

--- a/tracker.js
+++ b/tracker.js
@@ -7,7 +7,8 @@ var restler = require('restler'),
 
 function track() {
     var pkg = require(path.join(path.dirname(module.parent.filename), 'package.json')),
-        vcapApplication;
+        vcapApplication,
+        vcapServices;
 
     if (process.env.VCAP_APPLICATION) {
         vcapApplication = JSON.parse(process.env.VCAP_APPLICATION);
@@ -34,6 +35,15 @@ function track() {
         }
         if (vcapApplication.application_uris) {
             event.application_uris = vcapApplication.application_uris;
+        }
+        if (process.env.VCAP_SERVICES) {
+            vcapServices =  JSON.parse(process.env.VCAP_SERVICES);
+            if(Object.keys(vcapServices).length > 0) {
+                event.bound_vcap_services = {};
+                Object.keys(vcapServices).forEach(function(service_label) {
+                    event.bound_vcap_services[service_label] = { 'count': vcapServices[service_label].length };
+                });                
+            }
         }
 
         var url = 'https://deployment-tracker.mybluemix.net/api/v1/track';

--- a/tracker.js
+++ b/tracker.js
@@ -43,21 +43,19 @@ function track() {
                 event.bound_vcap_services = {};
                 // for each bound service count the number of instances and identify used plans
                 Object.keys(vcapServices).forEach(function(service_label) {
-                    event.bound_vcap_services[service_label] = { 
-                                                                 'count': vcapServices[service_label].length,   // number of service_label instances 
+                    event.bound_vcap_services[service_label] = {
+                                                                 'count': vcapServices[service_label].length,   // number of service_label instances
                                                                  'plans': []                                    // (optional) plan information for service_label
                                                                };
                     vcapServices[service_label].forEach(function (serviceInstance) {
                         if(serviceInstance.hasOwnProperty('plan')) {
-                            if(event.bound_vcap_services[service_label].plans.indexOf(serviceInstance.plan) === -1) {
-                                event.bound_vcap_services[service_label].plans.push(serviceInstance.plan);
-                            }
+                            event.bound_vcap_services[service_label].plans.push(serviceInstance.plan);
                         }
-                    });                                          
+                    });
 
                     // Keep plans property only if at least one plan is associated with this service
                     if(event.bound_vcap_services[service_label].plans.length === 0) {
-                        delete event.bound_vcap_services[service_label].plans;  
+                        delete event.bound_vcap_services[service_label].plans;
                     }
                 });
             }


### PR DESCRIPTION
- Added code to send information about bound services to the DT tracking service (see https://github.com/IBM-Bluemix/cf-deployment-tracker-service/issues/1)
- Updated privacy information in README
- Increased module version number to 0.1.0
- added support for `runtime` property, identifying the Bluemix runtime environment in which the tracked app is running. The property value is always `nodejs` for this DT client.
- capture service plan information 
