### PR TITLE
load package.json from cwd

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-deployment-tracker-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "main": "tracker.js",
   "repository": {
@@ -8,6 +8,7 @@
     "url": "https://github.com/IBM-Bluemix/cf-deployment-tracker-client-node.git"
   },
   "dependencies": {
+    "cwd": "^0.10.0",
     "restler": "3.3.0"
   },
   "author": [

--- a/tracker.js
+++ b/tracker.js
@@ -3,18 +3,25 @@
 'use strict';
 
 var restler = require('restler'),
-    path = require('path');
+    path = require('path'),
+    cwd = require('cwd');
 
 function track() {
-    var pkg = require(path.join(path.dirname(module.parent.filename), 'package.json')),
-        vcapApplication,
+    var pkg = null;
+    try {
+        pkg = require(path.join(cwd(), 'package.json'));
+    }
+    catch(ex) {
+        // package.json could not be loaded from the cwd
+    }
+    var vcapApplication,
         vcapServices;
 
     if (process.env.VCAP_APPLICATION) {
         vcapApplication = JSON.parse(process.env.VCAP_APPLICATION);
     }
 
-    if (vcapApplication) {
+    if ((vcapApplication) && (pkg)) {
         var event = {
             date_sent: new Date().toJSON()
         };


### PR DESCRIPTION
Changes:
* Use `cwd` to identify location of `package.json`
* Catch exception if `package.json` cannot be loaded from `cwd`
* Suppress tracking request if `package.json` could not be loaded because no valid deployment tracking record can be created

Tested the following nodejs DT client tracking scenarios:

- `node server.js` - `server.js` in `cwd` requires DT client `require("cf-deployment-tracker-client").track();` to track
- `node lib/server2.js` - `lib/server2.js` in subdirectory of `cwd` requires DT client `require("cf-deployment-tracker-client").track();` to track
- `node lib/server2a.js` - `lib/server2a.js` in subdirectory of `cwd` requires a local module `require("./lib/mymodule.js")();` which requires DT client `require("cf-deployment-tracker-client").track();` to track 
- `node lib/server2b.js` - `lib/server2b.js` in subdirectory of `cwd` requires a remote module `require("dtc-test-module")();` which requires DT client `require("cf-deployment-tracker-client").track();` to track
- `node lib/lab/server3.js` - `lib/lab/server3.js` in sub-subdirectory of `cwd` requires DT client `require("cf-deployment-tracker-client").track();` to track

During all tests `package.json` is located in `cwd`.
```
 Directory of D:\deployment-tracker\issues\node_cl_i9\sample-app-1\node-helloworld
 package.json
 server.js
 ...
 lib/server2.js
 lib/server2a.js
 lib/server2b.js
 lib/lib/mymodule.js
 lib/lab/server3.js


```


```
deployment-tracker\issues\node_cl_i9\sample-app-1\node-helloworld>node server
server.js: loading cf-deployment-tracker-client directly
Tracking payload: {"date_sent":"2016-11-10T01:36:51.776Z","code_version":"0.0.0","repository_url":"https://github.com/IBM-Bluemix/bluemix-hello-node.git","runtime":"nodejs"}
...
deployment-tracker\issues\node_cl_i9\sample-app-1\node-helloworld>node lib/server2
server2.js: loading cf-deployment-tracker-client directly
Tracking payload: {"date_sent":"2016-11-10T01:36:58.109Z","code_version":"0.0.0","repository_url":"https://github.com/IBM-Bluemix/bluemix-hello-node.git","runtime":"nodejs"}
...
deployment-tracker\issues\node_cl_i9\sample-app-1\node-helloworld>node lib/server2a
server2a.js: loading local module ./lib/mymodule.js
Tracking payload: {"date_sent":"2016-11-10T01:37:08.297Z","code_version":"0.0.0","repository_url":"https://github.com/IBM-Bluemix/bluemix-hello-node.git","runtime":"nodejs"}
...
deployment-tracker\issues\node_cl_i9\sample-app-1\node-helloworld>node lib/server2b
server2b.js: loading remote module dtc-test-module
Tracking payload: {"date_sent":"2016-11-10T01:37:17.703Z","code_version":"0.0.0","repository_url":"https://github.com/IBM-Bluemix/bluemix-hello-node.git","runtime":"nodejs"}
...
deployment-tracker\issues\node_cl_i9\sample-app-1\node-helloworld>node lib/lab/server3
server3.js: loading cf-deployment-tracker-client directly
Tracking payload: {"date_sent":"2016-11-10T01:55:28.386Z","code_version":"0.0.0","repository_url":"https://github.com/IBM-Bluemix/bluemix-hello-node.git","runtime":"nodejs"}
```